### PR TITLE
Fix test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libp2p-uds = { version = "0.8.0", path = "./transports/uds" }
 libp2p-wasm-ext = { version = "0.1.0", path = "./transports/wasm-ext" }
 libp2p-websocket = { version = "0.8.0", path = "./transports/websocket", optional = true }
 libp2p-yamux = { version = "0.8.0", path = "./muxers/yamux" }
-parking_lot = "0.7"
+parking_lot = "0.8"
 smallvec = "0.6"
 tokio-codec = "0.1"
 tokio-executor = "0.1"

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Where to ask questions?
 - https://github.com/paritytech/substrate
 - https://github.com/sigp/lighthouse
 - https://github.com/golemfactory/golem-libp2p
+- https://github.com/comit-network/comit-rs

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../misc/m
 multihash = { package = "parity-multihash", version = "0.1.0", path = "../misc/multihash" }
 multistream-select = { version = "0.4.0", path = "../misc/multistream-select" }
 futures = { version = "0.1", features = ["use_std"] }
-parking_lot = "0.7"
+parking_lot = "0.8"
 protobuf = "2.3"
 quick-error = "1.2"
 rand = "0.6"

--- a/core/src/nodes/handled_node_tasks.rs
+++ b/core/src/nodes/handled_node_tasks.rs
@@ -335,9 +335,12 @@ impl<TInEvent, TOutEvent, TIntoHandler, TReachErr, THandlerErr, TUserData, TConn
         for n in (0..self.local_spawns.len()).rev() {
             let mut task = self.local_spawns.swap_remove(n);
             match task.poll() {
-                Ok(Async::Ready(())) => (),
+                Ok(Async::Ready(())) => {},
                 Ok(Async::NotReady) => self.local_spawns.push(task),
-                Err(_err) => ()     // TODO: log this?
+                // It would normally be desirable to either report or log when a background task
+                // errors. However the default tokio executor doesn't do anything in case of error,
+                // and therefore we mimic this behaviour by also not doing anything.
+                Err(()) => {}
             }
         }
 

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = "1.3.1"
 bytes = "0.4.12"
 data-encoding = "2.1"
 multihash = { package = "parity-multihash", version = "0.1.0", path = "../multihash" }
+percent-encoding = "1.0.1"
 serde = "1.0.70"
 unsigned-varint = "0.2"
 url = { version = "1.7.2", default-features = false }

--- a/misc/multiaddr/tests/lib.rs
+++ b/misc/multiaddr/tests/lib.rs
@@ -98,8 +98,8 @@ impl Arbitrary for Proto {
             17 => Proto(Udt),
             18 => Proto(Unix(Cow::Owned(SubString::arbitrary(g).0))),
             19 => Proto(Utp),
-            20 => Proto(Ws),
-            21 => Proto(Wss),
+            20 => Proto(Ws("/".into())),
+            21 => Proto(Wss("/".into())),
             22 => {
                 let mut a = [0; 10];
                 g.fill(&mut a);
@@ -196,15 +196,15 @@ fn construct_success() {
     // /ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio
     ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
              "29200108A07AC542013AC986FFFE317095061F40DD03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![Ip6(addr6.clone()), Tcp(8000), Ws, P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))
+             vec![Ip6(addr6.clone()), Tcp(8000), Ws("/".into()), P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))
              ]);
     ma_valid("/p2p-webrtc-star/ip4/127.0.0.1/tcp/9090/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
              "9302047F000001062382DD03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![P2pWebRtcStar, Ip4(local.clone()), Tcp(9090), Ws, P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))
+             vec![P2pWebRtcStar, Ip4(local.clone()), Tcp(9090), Ws("/".into()), P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))
              ]);
     ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/wss/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
              "29200108A07AC542013AC986FFFE317095061F40DE03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![Ip6(addr6.clone()), Tcp(8000), Wss, P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))]);
+             vec![Ip6(addr6.clone()), Tcp(8000), Wss("/".into()), P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))]);
     ma_valid("/ip4/127.0.0.1/tcp/9090/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
              "047F000001062382A202A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
              vec![Ip4(local.clone()), Tcp(9090), P2pCircuit, P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))]);

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -15,7 +15,7 @@ fnv = "1.0"
 futures = "0.1"
 libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4"
-parking_lot = "0.7"
+parking_lot = "0.8"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.1"
 libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4.1"
 multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../../misc/multiaddr" }
-parking_lot = "0.7"
+parking_lot = "0.8"
 protobuf = "2.3"
 smallvec = "0.6"
 tokio-codec = "0.1"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -21,7 +21,7 @@ libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4"
 multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../../misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.1.0", path = "../../misc/multihash" }
-parking_lot = "0.7"
+parking_lot = "0.8"
 protobuf = "2.3"
 rand = "0.6.0"
 sha2 = "0.8.0"

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -361,7 +361,7 @@ where
 
         // While iterating over peers, count the number of queries in a row (from closer to further
         // away from target) that are in the succeeded state.
-        let mut succeeded_counter = 0;
+        let mut succeeded_counter = Some(0);
 
         // Extract `self.num_results` to avoid borrowing errors with closures.
         let num_results = self.num_results;
@@ -375,15 +375,16 @@ where
                         return Async::Ready(QueryStatePollOut::CancelRpc { peer_id: peer_id.preimage() });
                     }
                     Ok(Async::NotReady) => {
+                        succeeded_counter = None;
                         active_counter += 1
                     }
                 }
             }
 
             if let QueryPeerState::Succeeded = state {
-                succeeded_counter += 1;
+                succeeded_counter.as_mut().map(|c| *c += 1);
                 // If we have enough results; the query is done.
-                if succeeded_counter >= num_results {
+                if succeeded_counter.unwrap_or(0) >= num_results {
                     return Async::Ready(QueryStatePollOut::Finished)
                 }
             }

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -20,7 +20,7 @@ ring = { version = "0.14", features = ["use_heap"], default-features = false }
 snow = { version = "0.5.2", features = ["ring-resolver"], default-features = false }
 tokio-io = "0.1"
 x25519-dalek = "0.5"
-zeroize = "0.5"
+zeroize = "0.8"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -16,7 +16,7 @@ libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4.1"
 multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../../misc/multiaddr" }
 futures = "0.1"
-parking_lot = "0.7"
+parking_lot = "0.8"
 rand = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-secio"
 edition = "2018"
 description = "Secio encryption protocol for libp2p"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -33,7 +33,7 @@ untrusted = { version = "0.6" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.10"
-send_wrapper = "0.2"
+parity-send-wrapper = "0.1"
 wasm-bindgen = "0.2.33"
 wasm-bindgen-futures = "0.3.10"
 web-sys = { version = "0.3.10", features = ["Crypto", "CryptoKey", "SubtleCrypto", "Window"] }

--- a/protocols/secio/src/exchange/impl_webcrypto.rs
+++ b/protocols/secio/src/exchange/impl_webcrypto.rs
@@ -22,7 +22,7 @@
 
 use crate::{KeyAgreement, SecioError};
 use futures::prelude::*;
-use send_wrapper::SendWrapper;
+use parity_send_wrapper::SendWrapper;
 use std::io;
 use wasm_bindgen::prelude::*;
 

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 futures = "0.1"
 js-sys = "0.3.19"
 libp2p-core = { version = "0.8.0", path = "../../core" }
-send_wrapper = "0.2.0"
+parity-send-wrapper = "0.1.0"
 tokio-io = "0.1"
 wasm-bindgen = "0.2.42"
 wasm-bindgen-futures = "0.3.19"

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -34,7 +34,7 @@
 
 use futures::{future::FutureResult, prelude::*, stream::Stream, try_ready};
 use libp2p_core::{transport::ListenerEvent, transport::TransportError, Multiaddr, Transport};
-use send_wrapper::SendWrapper;
+use parity_send_wrapper::SendWrapper;
 use std::{collections::VecDeque, error, fmt, io, mem};
 use wasm_bindgen::{JsCast, prelude::*};
 

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -298,41 +298,41 @@ fn multiaddr_to_target(addr: &Multiaddr) -> Result<String, ()> {
     }
 
     match (&protocols[0], &protocols[1], &protocols[2]) {
-        (&Protocol::Ip4(ref ip), &Protocol::Tcp(port), &Protocol::Ws) => {
+        (&Protocol::Ip4(ref ip), &Protocol::Tcp(port), &Protocol::Ws(ref ws_path)) => {
             if ip.is_unspecified() || port == 0 {
                 return Err(());
             }
-            Ok(format!("ws://{}:{}/", ip, port))
+            Ok(format!("ws://{}:{}{}", ip, port, ws_path))
         }
-        (&Protocol::Ip6(ref ip), &Protocol::Tcp(port), &Protocol::Ws) => {
+        (&Protocol::Ip6(ref ip), &Protocol::Tcp(port), &Protocol::Ws(ref ws_path)) => {
             if ip.is_unspecified() || port == 0 {
                 return Err(());
             }
-            Ok(format!("ws://[{}]:{}/", ip, port))
+            Ok(format!("ws://[{}]:{}{}", ip, port, ws_path))
         }
-        (&Protocol::Ip4(ref ip), &Protocol::Tcp(port), &Protocol::Wss) => {
+        (&Protocol::Ip4(ref ip), &Protocol::Tcp(port), &Protocol::Wss(ref ws_path)) => {
             if ip.is_unspecified() || port == 0 {
                 return Err(());
             }
-            Ok(format!("wss://{}:{}/", ip, port))
+            Ok(format!("wss://{}:{}{}", ip, port, ws_path))
         }
-        (&Protocol::Ip6(ref ip), &Protocol::Tcp(port), &Protocol::Wss) => {
+        (&Protocol::Ip6(ref ip), &Protocol::Tcp(port), &Protocol::Wss(ref ws_path)) => {
             if ip.is_unspecified() || port == 0 {
                 return Err(());
             }
-            Ok(format!("wss://[{}]:{}/", ip, port))
+            Ok(format!("wss://[{}]:{}{}", ip, port, ws_path))
         }
-        (&Protocol::Dns4(ref ns), &Protocol::Tcp(port), &Protocol::Ws) => {
-            Ok(format!("ws://{}:{}/", ns, port))
+        (&Protocol::Dns4(ref ns), &Protocol::Tcp(port), &Protocol::Ws(ref ws_path)) => {
+            Ok(format!("ws://{}:{}{}", ns, port, ws_path))
         }
-        (&Protocol::Dns6(ref ns), &Protocol::Tcp(port), &Protocol::Ws) => {
-            Ok(format!("ws://{}:{}/", ns, port))
+        (&Protocol::Dns6(ref ns), &Protocol::Tcp(port), &Protocol::Ws(ref ws_path)) => {
+            Ok(format!("ws://{}:{}{}", ns, port, ws_path))
         }
-        (&Protocol::Dns4(ref ns), &Protocol::Tcp(port), &Protocol::Wss) => {
-            Ok(format!("wss://{}:{}/", ns, port))
+        (&Protocol::Dns4(ref ns), &Protocol::Tcp(port), &Protocol::Wss(ref ws_path)) => {
+            Ok(format!("wss://{}:{}{}", ns, port, ws_path))
         }
-        (&Protocol::Dns6(ref ns), &Protocol::Tcp(port), &Protocol::Wss) => {
-            Ok(format!("wss://{}:{}/", ns, port))
+        (&Protocol::Dns6(ref ns), &Protocol::Tcp(port), &Protocol::Wss(ref ws_path)) => {
+            Ok(format!("wss://{}:{}{}", ns, port, ws_path))
         }
         _ => Err(()),
     }


### PR DESCRIPTION
The problem with the test is the following: It is publishing to `swarms[31]`, but `swarms[31]` only gets to know about `swarms[0]` to `swarms[29]`. `swarms[31]` does a `FIND_NODE` before the `PUT_VALUE`, but that won't make it discover `swarms[30]`, because all the `FIND_NODE` replies will have an empty list of closer peers. And that is because when receiving a `PUT_VALUE`,  while the receiver adds the sender to its k-buckets, it apparently has no address for it (https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/src/behaviour.rs#L504-L507). That may be a separate issue, but I suggest to just make your test simpler, as mentioned in the PR comments. A separate mistake in the expectations of the test is that they expect 21 peers in `have_key` but that should be 20 because you are (on purpose) excluding `swarm[31]`, the publisher, from the swarms you issue a `get_value` on.